### PR TITLE
feat: migrate illustration library page

### DIFF
--- a/docs/assets/illustration-library/illustration-library.md
+++ b/docs/assets/illustration-library/illustration-library.md
@@ -2,6 +2,10 @@
 sidebar_position: 3
 ---
 
+import IllustrationLibrary from '@site/src/components/illustration-library/illustration-library';
+
 # Illustration library
 
-Illustration library here...
+Illustrations are a key element of the Tyler brand system. Illustrations provide a sense of personality and familiarity and can make complex ideas more accessible.
+
+<IllustrationLibrary />

--- a/src/components/icon-library/icon-library.tsx
+++ b/src/components/icon-library/icon-library.tsx
@@ -28,7 +28,7 @@ export default function IconLibrary() {
 
   const fetchMetadata = async (): Promise<void> => {
     try {
-      const response = await window.fetch(METADATA_URI);
+      const response = await window.fetch(`${METADATA_URI}?t=${new Date().getTime()}`);
       const data = await response.json() as IconMetadata;
       setStandardIcons(data.find(({ name }) => name === 'Standard').icons);
       setExtendedIcons(data.find(({ name }) => name === 'Extended').icons);
@@ -107,7 +107,7 @@ function Icon({ name, data }) {
       <div className={styles.iconLabel}>{name}</div>
       <div className={styles.icon} dangerouslySetInnerHTML={{ __html: data }}></div>
       <div className={styles.iconActions}>
-        <button className="clean-btn" type="button" onClick={() => navigator.clipboard.writeText(name)}>
+        <button className="clean-btn" type="button" onClick={() => navigator.clipboard.writeText(data)} title="Copy SVG data">
           <svg viewBox="0 0 24 24">
             <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
           </svg>

--- a/src/components/illustration-library/illustration-library.module.css
+++ b/src/components/illustration-library/illustration-library.module.css
@@ -1,0 +1,87 @@
+.illustrationGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  width: calc(100% - 2px);
+  margin-bottom: 1px;
+}
+
+.illustrationGridHeader {
+  margin-top: 48px;
+}
+
+.loading {
+  padding: 16px;
+}
+
+.illustrationContainer {
+  background-color: var(--forge-theme-surface);
+  outline: 1px solid var(--forge-theme-border);
+  margin-left: 1px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  min-height: 150px;
+}
+
+.illustrationLabel {
+  margin: 0;
+  padding: 4px 8px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--forge-theme-text-secondary);
+  font-size: 12px;
+  max-width: 150px;
+}
+
+.illustration {
+  height: 100%;
+  width: 100%;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.illustration > svg {
+  fill: currentColor;
+  height: 1em;
+  width: 1em;
+  display: flex;
+  align-items: center;
+}
+
+.buttonContainer {
+  padding-top: 16px;
+}
+
+.illustrationActions {
+  visibility: hidden;
+  position: absolute;
+  bottom: 0;
+  right: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.illustrationActions > button > svg {
+  fill: var(--forge-theme-text-secondary);
+  transition: fill linear 300ms;
+  opacity: 0.5;
+  width: 20px;
+  height: 20px;
+}
+
+.illustrationActions > button > svg:hover {
+  fill: var(--forge-theme-text-primary);
+  opacity: 1;
+}
+
+.illustrationContainer:hover .illustrationActions {
+  visibility: visible;
+}

--- a/src/components/illustration-library/illustration-library.tsx
+++ b/src/components/illustration-library/illustration-library.tsx
@@ -1,0 +1,174 @@
+import React, { SyntheticEvent, useEffect, useState } from 'react';
+import InputField from '../controls/text-input/text-input';
+import styles from './illustration-library.module.css';
+
+const MORE_ILLUSTRATIONS_INCREMENT = 24;
+const METADATA_URI = 'https://cdn.forge.tylertech.com/v1/metadata/illustrations/illustration-metadata.json';
+
+interface IIllustration {
+  name: string;
+  formats: string[];
+  urls: Array<IIllustrationUrl>;
+  type: 'spot' | 'spot-hero' | 'hero';
+  keywords: string[];
+  preferredUrl: string;
+}
+
+interface IIllustrationUrl {
+  type: string;
+  url: string;
+}
+
+type IllustrationMetadata = Array<IIllustration>;
+
+export default function IllustrationLibrary() {
+  const [isLoading, setLoading] = useState(true);
+  const [filterText, setFilterText] = useState('');
+  const [spotIllustrations, setSpotIllustrations] = useState([]);
+  const [spotHeroIllustrations, setSpotHeroIllustrations] = useState([]);
+  const [heroIllustrations, setHeroIllustrations] = useState([]);
+
+  const fetchMetadata = async (): Promise<void> => {
+    try {
+      const { spots, spotHeros, heros } = await loadData();
+      setSpotIllustrations(spots);
+      setSpotHeroIllustrations(spotHeros);
+      setHeroIllustrations(heros);
+      setLoading(false);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    fetchMetadata();
+  }, []);
+
+  function handleFilter(evt: SyntheticEvent): void {
+    setFilterText((evt.nativeEvent.target as HTMLInputElement).value);
+  }
+
+  return (
+    <div>
+      <InputField onInput={handleFilter} placeholder="Filter..." />
+      {isLoading && <div className={styles.loading}>Loading illustrations...</div>}
+      {!isLoading &&
+        <>
+          <IllustrationGrid header="Spot" illustrations={spotIllustrations} filterText={filterText} />
+          <IllustrationGrid header="Spot hero" illustrations={spotHeroIllustrations} filterText={filterText} />
+          <IllustrationGrid header="Hero" illustrations={heroIllustrations} filterText={filterText} />
+        </>}
+    </div>
+  );
+}
+
+function IllustrationGrid({ header, illustrations, filterText }) {
+  const [visibleIllustrations, setVisibleIllustrations] = useState([]);
+  const [canShowMore, setCanShowMore] = useState(true);
+  
+  useEffect(() => {
+    calcVisibleIllustrations([]);
+  }, [filterText]);
+
+  function calcVisibleIllustrations(currentIllustrations) {
+    const filteredIllustrations = filterIllustrations(illustrations);
+    const renderIllustrations = filteredIllustrations.slice(0, currentIllustrations.length + MORE_ILLUSTRATIONS_INCREMENT);
+    setVisibleIllustrations(renderIllustrations);
+    setCanShowMore(filteredIllustrations.length > MORE_ILLUSTRATIONS_INCREMENT);
+  }
+
+  function filterIllustrations(illustrations) {
+    return illustrations.filter(i => {
+      return [i.name, ...i.keywords].some(val => val.trim().toLowerCase().includes(filterText.trim().toLowerCase()));
+    });
+  }
+
+  return (
+    <>
+      <h2 className={styles.illustrationGridHeader}>{header}</h2>
+      {!!visibleIllustrations.length &&
+        <>
+          <div className={styles.illustrationGrid}>
+            {visibleIllustrations.map(({ name, preferredUrl }) => <Illustration key={name} name={name} url={preferredUrl} />)}
+          </div>
+          {canShowMore && 
+            <div className={styles.buttonContainer}>
+              <button className="button button--primary" type="button" onClick={() => calcVisibleIllustrations(visibleIllustrations)}>Show more...</button>
+            </div>}
+        </>}
+      {visibleIllustrations.length === 0 && <div>No matching illustrations</div>}
+    </>
+  );
+}
+
+function Illustration({ name, url }) {
+  return (
+    <div className={styles.illustrationContainer}>
+      <div className={styles.illustrationLabel}>{name}</div>
+      <div className={styles.illustration}>
+        <img loading="lazy" src={url} alt="" />
+      </div>
+      <div className={styles.illustrationActions}>
+        <button className="clean-btn" type="button" onClick={() => downloadImage(url)} title="Download image">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+        </button>
+
+        <button className="clean-btn" type="button" onClick={() => navigator.clipboard.writeText(`<img src="${url}" alt="" />`)} title="Copy code">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
+        </button>
+
+        <button className="clean-btn" type="button" onClick={() => navigator.clipboard.writeText(url)} title="Copy CDN link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+async function loadData() {
+  const response = await window.fetch(`${METADATA_URI}?t=${new Date().getTime()}`);
+  const data = await response.json() as IllustrationMetadata;
+  
+  const spots = [];
+  const spotHeros = [];
+  const heros = [];
+
+  data.forEach(illustration => {
+    switch (illustration.type) {
+      case 'spot':
+        spots.push(illustration);
+        break;
+      case 'spot-hero':
+        spotHeros.push(illustration);
+        break;
+      case 'hero':
+        heros.push(illustration);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return { spots, spotHeros, heros };
+}
+
+function downloadImage(url) {
+  const imageDownloadName = new URL(url).pathname.split('/').pop();
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', `${url}?x-forge=true`, true);
+  xhr.responseType = 'blob';
+  xhr.onload = function() {
+    var urlCreator = window.URL || window.webkitURL;
+    var imageUrl = urlCreator.createObjectURL(this.response);
+    var tag = document.createElement('a');
+    tag.href = imageUrl;
+    tag.download = imageDownloadName;
+    document.body.appendChild(tag);
+    tag.click();
+    document.body.removeChild(tag);
+  };
+  xhr.send();
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -18,6 +18,7 @@ import ServicesBlock from '@site/src/components/services-block/services-block';
 
 export default {
   ...MDXComponents,
+  img: (props) => <MDXComponents.img {...props} alt={props.alt ?? ''} />,
   blockquote: props => <blockquote {...props} className="forge-blockquote" />,
   ComponentVisual,
   StatusBadges,


### PR DESCRIPTION
Migrated the illustration library page and modified it to fetch metadata from CDN instead of Airtable, as well as updated the design to match the icon library for consistency.