### PR TITLE
fix(illustration library): disable caching of illustration metadata

### DIFF
--- a/src/components/illustration-library/illustration-library.tsx
+++ b/src/components/illustration-library/illustration-library.tsx
@@ -129,7 +129,7 @@ function Illustration({ name, url }) {
 }
 
 async function loadData() {
-  const response = await window.fetch(`${METADATA_URI}?t=${new Date().getTime()}`);
+  const response = await window.fetch(`${METADATA_URI}?t=${new Date().getTime()}`, { cache: 'no-cache' });
   const data = await response.json() as IllustrationMetadata;
   
   const spots = [];


### PR DESCRIPTION
Set `cache` to `no-cache` on metadata JSON request from CDN to avoid browser caching.